### PR TITLE
Update configuration for basemail

### DIFF
--- a/resources/config/config.toml
+++ b/resources/config/config.toml
@@ -15,22 +15,9 @@ bind = ["[::]:465"]
 protocol = "smtp"
 tls.implicit = true
 
-[server.listener."imap"]
-bind = ["[::]:143"]
-protocol = "imap"
-
 [server.listener."imaptls"]
 bind = ["[::]:993"]
 protocol = "imap"
-tls.implicit = true
-
-[server.listener.pop3]
-bind = "[::]:110"
-protocol = "pop3"
-
-[server.listener.pop3s]
-bind = "[::]:995"
-protocol = "pop3"
 tls.implicit = true
 
 [server.listener."sieve"]
@@ -47,15 +34,20 @@ data = "rocksdb"
 fts = "rocksdb"
 blob = "rocksdb"
 lookup = "rocksdb"
-directory = "internal"
+directory = "basemail"
 
 [store."rocksdb"]
 type = "rocksdb"
 path = "%{env:STALWART_PATH}%/data"
 compression = "lz4"
 
-[directory."internal"]
-type = "internal"
+[directory."basemail"]
+type = "basemail"
+api_url = "%{env:AUTH_SERVER_URL}%"
+chain_id = "%{env:CHAIN_ID}%"
+rpc_url = "%{env:RPC_URL}%"
+basemail_address = "%{env:BASEMAIL_ADDRESS}%"
+
 store = "rocksdb"
 
 [tracer."stdout"]
@@ -63,11 +55,3 @@ type = "stdout"
 level = "info"
 ansi = false
 enable = true
-
-#[server.run-as]
-#user = "stalwart-mail"
-#group = "stalwart-mail"
-
-[authentication.fallback-admin]
-user = "admin"
-secret = "%{env:ADMIN_SECRET}%"


### PR DESCRIPTION
Edits to the `resources/config/config.toml` file for basemail:
- Swaps out the default "internal" directory for the custom "basemail" one that we intend to use. It expects inputs from new environment variables, which makes it easier to change during development without rebuilding the docker image.
- Removes listeners on various ports that are not going to be needed in our setup based on the recommendations provided here: https://stalw.art/docs/get-started#choosing-network-ports

I assume we will have TLS enabled, which we need to confirm is auto-configured in the setup script.