### PR TITLE
fix(basemail_module): validate call

### DIFF
--- a/crates/directory/src/backend/basemail/mod.rs
+++ b/crates/directory/src/backend/basemail/mod.rs
@@ -39,11 +39,11 @@ impl BasemailDirectory {
             "access_token": token
         });
         let response = client
-            .get(&format!("{}/validate/", self.api_url))
+            .post(&format!("{}/validate", self.api_url))
             .json(&payload)
             .send()
             .await;
-        
+
         // Parse the response and return a value
         match response {
             Ok(response) => {


### PR DESCRIPTION
This is supposed to be a `post` call so a json payload can be submitted,
as `get` cannot submit payloads.

The trailing `/` has also been removed to keep consistency with the
other auth server routes
